### PR TITLE
Add flt type support

### DIFF
--- a/smc.cpp
+++ b/smc.cpp
@@ -72,6 +72,10 @@ float _strtof(char *str, int size, int e) {
   return total;
 }
 
+void printFLT(SMCVal_t val) {
+  printf("%.0f ", *reinterpret_cast<float*>(val.bytes));
+}
+
 void printFPE2(SMCVal_t val) {
   /* FIXME: This decode is incomplete, last 2 bits are dropped */
 
@@ -100,6 +104,8 @@ void printVal(SMCVal_t val) {
       printUInt(val);
     else if (strcmp(val.dataType, DATATYPE_FPE2) == 0)
       printFPE2(val);
+    else if (strcmp(val.dataType, DATATYPE_FLT) == 0)
+      printFLT(val);
 
     printBytesHex(val);
   } else {

--- a/smc.h
+++ b/smc.h
@@ -53,6 +53,7 @@
 #define DATATYPE_UINT16 "ui16"
 #define DATATYPE_UINT32 "ui32"
 #define DATATYPE_SP78 "sp78"
+#define DATATYPE_FLT "flt "
 
 // key values
 /*#define SMC_KEY_CPU_TEMP      "TC0D"


### PR DESCRIPTION
The "flt" type found on MacBook Pro 13-inch 2019 is "little endian float", this patch helps to interpret it.

Sample output (fan speed):

```
  F0Ac  [flt ]  2634 (bytes 39 9a 24 45)
  F1Ac  [flt ]  2828 (bytes 17 bf 30 45)
```